### PR TITLE
Get job outputs on failure

### DIFF
--- a/azimuth_caas_operator/operator.py
+++ b/azimuth_caas_operator/operator.py
@@ -142,10 +142,8 @@ async def cluster_create(body, name, namespace, labels, **kwargs):
             raise kopf.TemporaryError(msg, delay=20)
 
         # if the job finished, update the cluster
+        outputs = await ansible_runner.get_outputs_from_job(K8S_CLIENT, create_job)
         if is_job_success:
-            outputs = await ansible_runner.get_outputs_from_create_job(
-                K8S_CLIENT, name, namespace
-            )
             await cluster_utils.update_cluster(
                 K8S_CLIENT,
                 name,
@@ -169,6 +167,7 @@ async def cluster_create(body, name, namespace, labels, **kwargs):
                 cluster_crd.ClusterPhase.FAILED,
                 # TODO(johngarbutt): we to better information on the reason!
                 error=error,
+                outputs=outputs,
             )
             LOG.error(f"Create job failed for {name} in {namespace} because {reason}")
             return
@@ -232,10 +231,8 @@ async def cluster_update(body, name, namespace, labels, **kwargs):
             raise kopf.TemporaryError(msg, delay=20)
 
         # if the job finished, update the cluster
+        outputs = await ansible_runner.get_outputs_from_job(K8S_CLIENT, update_job)
         if is_job_success:
-            outputs = await ansible_runner.get_outputs_from_create_job(
-                K8S_CLIENT, name, namespace
-            )
             await ansible_runner.unlabel_job(K8S_CLIENT, update_job)
             await cluster_utils.update_cluster(
                 K8S_CLIENT,
@@ -261,6 +258,7 @@ async def cluster_update(body, name, namespace, labels, **kwargs):
                 cluster_crd.ClusterPhase.FAILED,
                 # TODO(johngarbutt): we to better information on the reason!
                 error=error,
+                outputs=outputs,
             )
             LOG.error(f"Update job failed for {name} in {namespace} because {reason}")
             return

--- a/azimuth_caas_operator/tests/test_operator.py
+++ b/azimuth_caas_operator/tests/test_operator.py
@@ -79,7 +79,7 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
         )
 
     @mock.patch.object(ansible_runner, "get_job_completed_state")
-    @mock.patch.object(ansible_runner, "get_outputs_from_create_job")
+    @mock.patch.object(ansible_runner, "get_outputs_from_job")
     @mock.patch.object(cluster_utils, "update_cluster")
     @mock.patch.object(ansible_runner, "get_create_job_for_cluster")
     async def test_cluster_create_spots_successful_job(
@@ -103,7 +103,7 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
             cluster_crd.ClusterPhase.READY,
             outputs={"asdf": 42},
         )
-        mock_outputs.assert_awaited_once_with(operator.K8S_CLIENT, "cluster1", "ns")
+        mock_outputs.assert_awaited_once_with(operator.K8S_CLIENT, "fakejob")
         mock_get_jobs.assert_awaited_once_with(operator.K8S_CLIENT, "cluster1", "ns")
         mock_success.assert_called_once_with("fakejob")
 
@@ -157,7 +157,7 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
         mock_completed.assert_called_once_with("update-job")
 
     @mock.patch.object(ansible_runner, "unlabel_job")
-    @mock.patch.object(ansible_runner, "get_outputs_from_create_job")
+    @mock.patch.object(ansible_runner, "get_outputs_from_job")
     @mock.patch.object(cluster_utils, "update_cluster")
     @mock.patch.object(ansible_runner, "get_job_completed_state")
     @mock.patch.object(ansible_runner, "get_update_job_for_cluster")
@@ -187,14 +187,14 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
             cluster_crd.ClusterPhase.READY,
             outputs={"asdf": 42},
         )
-        mock_outputs.assert_awaited_once_with(operator.K8S_CLIENT, "cluster1", "ns")
+        mock_outputs.assert_awaited_once_with(operator.K8S_CLIENT, "update-job")
         mock_update_job.assert_awaited_once_with(operator.K8S_CLIENT, "cluster1", "ns")
         mock_completed.assert_called_once_with("update-job")
         mock_unlabel.assert_awaited_once_with(operator.K8S_CLIENT, "update-job")
 
     @mock.patch.object(ansible_runner, "unlabel_job")
     @mock.patch.object(ansible_runner, "get_job_error_message")
-    @mock.patch.object(ansible_runner, "get_outputs_from_create_job")
+    @mock.patch.object(ansible_runner, "get_outputs_from_job")
     @mock.patch.object(cluster_utils, "update_cluster")
     @mock.patch.object(ansible_runner, "get_job_completed_state")
     @mock.patch.object(ansible_runner, "get_update_job_for_cluster")
@@ -226,6 +226,7 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
             cluster_crd.ClusterPhase.FAILED,
             error="Failed to update the platform. To retry please click patch. "
             "Possible reason for the failure was: oops",
+            outputs={"asdf": 42},
         )
         mock_update_job.assert_awaited_once_with(operator.K8S_CLIENT, "cluster1", "ns")
         mock_completed.assert_called_once_with("update-job")
@@ -268,18 +269,20 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
         )
         mock_update_job.assert_awaited_once_with(operator.K8S_CLIENT, "cluster1", "ns")
 
+    @mock.patch.object(ansible_runner, "get_outputs_from_job")
     @mock.patch.object(ansible_runner, "get_job_error_message")
     @mock.patch.object(cluster_utils, "update_cluster")
     @mock.patch.object(ansible_runner, "get_job_completed_state")
     @mock.patch.object(ansible_runner, "get_create_job_for_cluster")
     async def test_cluster_create_raise_on_failed_jobs(
-        self, mock_get_jobs, mock_success, mock_update, mock_error
+        self, mock_get_jobs, mock_success, mock_update, mock_error, mock_outputs
     ):
         # TODO(johngarbutt): should generate a working fake job list!
         mock_get_jobs.return_value = "fakejob"
         mock_success.return_value = False
         fake_body = cluster_crd.get_fake_dict()
         mock_error.return_value = "oops"
+        mock_outputs.return_value = {"asdf": 42}
 
         await operator.cluster_create(fake_body, "cluster1", "ns", {})
 
@@ -291,9 +294,11 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
             error="Failed to create platform. "
             "To retry please click patch. "
             "Possible reason for the failure was: oops",
+            outputs={"asdf": 42},
         )
         mock_get_jobs.assert_awaited_once_with(operator.K8S_CLIENT, "cluster1", "ns")
         mock_success.assert_called_once_with("fakejob")
+        mock_outputs.assert_awaited_once_with(operator.K8S_CLIENT, "fakejob")
         mock_error.assert_awaited_once_with(operator.K8S_CLIENT, "fakejob")
 
     @mock.patch.object(cluster_utils, "update_cluster")

--- a/azimuth_caas_operator/tests/utils/test_ansible_runner.py
+++ b/azimuth_caas_operator/tests/utils/test_ansible_runner.py
@@ -208,7 +208,7 @@ class TestAsyncUtils(unittest.IsolatedAsyncioTestCase):
         list_iter = async_utils.AsyncIterList(fake_job_list)
         mock_job_resource.return_value = list_iter
 
-        jobs = await ansible_runner.get_jobs_for_cluster("client", "cluster1", "ns")
+        jobs = await ansible_runner._get_jobs_for_cluster("client", "cluster1", "ns")
 
         self.assertEqual(fake_job_list, jobs)
         mock_job_resource.assert_awaited_once_with("client")
@@ -229,7 +229,7 @@ class TestAsyncUtils(unittest.IsolatedAsyncioTestCase):
         list_iter = async_utils.AsyncIterList(fake_job_list)
         mock_job_resource.return_value = list_iter
 
-        jobs = await ansible_runner.get_jobs_for_cluster(
+        jobs = await ansible_runner._get_jobs_for_cluster(
             "client", "cluster1", "ns", remove=True
         )
 


### PR DESCRIPTION
Also fix that the update job was looking at the create job outputs, and not the latest update job.