### PR TITLE
Don't use resource uid as cluster_id

### DIFF
--- a/azimuth_caas_operator/utils/ansible_runner.py
+++ b/azimuth_caas_operator/utils/ansible_runner.py
@@ -90,7 +90,7 @@ def get_env_configmap(
 ):
     extraVars = dict(cluster_type_spec.extraVars, **cluster.spec.extraVars)
     extraVars["cluster_name"] = cluster.metadata.name
-    extraVars["cluster_id"] = cluster.metadata.uid
+    extraVars["cluster_id"] = f"{cluster.metadata.namespace}--{cluster.metadata.name}"
     extraVars["cluster_type"] = cluster.spec.clusterTypeName
     extraVars["cluster_deploy_ssh_public_key"] = cluster_deploy_ssh_public_key
     # This is the file containing the private key for the deploy key


### PR DESCRIPTION
Using uid causes new Azimuth restore functionality to break since the restored resource has a different uid so the terraform state is not correctly re-adopted.