### PR TITLE
Remove ui-meta validation

### DIFF
--- a/azimuth_caas_operator/models/v1alpha1/cluster_type.py
+++ b/azimuth_caas_operator/models/v1alpha1/cluster_type.py
@@ -1,5 +1,4 @@
 import datetime
-import typing
 
 import kube_custom_resource as crd
 from kube_custom_resource import schema
@@ -12,60 +11,9 @@ class ClusterTypePhase(str, schema.Enum):
     FAILED = "Failed"
 
 
-class ClusterParameter(schema.BaseModel):
-    #: The name of the parameter
-    name: str
-    #: A human-readable label for the parameter
-    label: str
-    #: A description of the parameter
-    description: schema.Optional[str] = None
-    #: The kind of the parameter
-    kind: str
-    #: A dictionary of kind-specific options for the parameter
-    options: schema.Dict[str, schema.Any] = pydantic.Field(default_factory=dict)
-    #: Indicates if the option is immutable, i.e. cannot be updated
-    immutable: schema.Optional[bool] = None
-    #: Indicates if the parameter is required
-    required: schema.Optional[bool] = None
-    #: A default value for the parameter
-    default: schema.Optional[schema.Any] = None
-
-
-class ClusterServiceSpec(schema.BaseModel):
-    #: The name of the service
-    name: str
-    #: A human-readable label for the service
-    label: str
-    #: The URL of an icon for the service
-    iconUrl: schema.Optional[str] = None
-    #: An expression indicating when the service is available
-    when: schema.Optional[str] = None
-
-
-class ClusterUiMeta(schema.BaseModel):
-    #: The name of the cluster type
-    name: str
-    #: A human-readable label for the cluster type
-    label: str
-    #: A description of the cluster type
-    description: schema.Optional[str] = None
-    #: The URL or data URI of the logo for the cluster type
-    logo: schema.Optional[str] = None
-    #: Indicates whether the cluster requires a user SSH key
-    requiresSshKey: schema.Optional[bool] = None
-    #: The parameters for the cluster type
-    parameters: typing.Sequence[ClusterParameter] = pydantic.Field(default_factory=list)
-    #: The services for the cluster type
-    services: typing.Sequence[ClusterServiceSpec] = pydantic.Field(default_factory=list)
-    #: Template for the usage of the clusters deployed using this type
-    #: Can use Jinja2 syntax and should produce valid Markdown
-    #: Receives the cluster parameters, as defined in `parameters`, as template args
-    usageTemplate: schema.Optional[str] = None
-
-
 class ClusterTypeStatus(schema.BaseModel):
     phase: ClusterTypePhase = pydantic.Field(ClusterTypePhase.PENDING)
-    uiMeta: schema.Optional[ClusterUiMeta] = None
+    uiMeta: schema.Dict[str, schema.Any] = pydantic.Field(default_factory=dict)
     uiMetaUrl: schema.Optional[schema.AnyHttpUrl] = None
     updatedTimestamp: schema.Optional[datetime.datetime] = pydantic.Field(
         None, description="The timestamp at which the resource was updated."

--- a/azimuth_caas_operator/tests/models/test_crds.py
+++ b/azimuth_caas_operator/tests/models/test_crds.py
@@ -100,107 +100,11 @@ class TestModels(base.TestCase):
                     "type": "string"
                   },
                   "uiMeta": {
-                    "nullable": true,
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "label": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "logo": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "requiresSshKey": {
-                        "nullable": true,
-                        "type": "boolean"
-                      },
-                      "parameters": {
-                        "items": {
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "label": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "nullable": true,
-                              "type": "string"
-                            },
-                            "kind": {
-                              "type": "string"
-                            },
-                            "options": {
-                              "additionalProperties": {
-                                "x-kubernetes-preserve-unknown-fields": true
-                              },
-                              "type": "object",
-                              "x-kubernetes-preserve-unknown-fields": true
-                            },
-                            "immutable": {
-                              "nullable": true,
-                              "type": "boolean"
-                            },
-                            "required": {
-                              "nullable": true,
-                              "type": "boolean"
-                            },
-                            "default": {
-                              "nullable": true,
-                              "x-kubernetes-preserve-unknown-fields": true
-                            }
-                          },
-                          "required": [
-                            "name",
-                            "label",
-                            "kind"
-                          ],
-                          "type": "object"
-                        },
-                        "type": "array"
-                      },
-                      "services": {
-                        "items": {
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "label": {
-                              "type": "string"
-                            },
-                            "iconUrl": {
-                              "nullable": true,
-                              "type": "string"
-                            },
-                            "when": {
-                              "nullable": true,
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "name",
-                            "label"
-                          ],
-                          "type": "object"
-                        },
-                        "type": "array"
-                      },
-                      "usageTemplate": {
-                        "nullable": true,
-                        "type": "string"
-                      }
+                    "additionalProperties": {
+                      "x-kubernetes-preserve-unknown-fields": true
                     },
-                    "required": [
-                      "name",
-                      "label"
-                    ],
-                    "type": "object"
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
                   "uiMetaUrl": {
                     "format": "uri",


### PR DESCRIPTION
The UI meta is really for Azimuth - we are only loading it here as a cache to avoid Azimuth loading it every time. So we don't need to validate it. This will make adding features in Azimuth that involve changes to the UI meta much easier.