### PR TITLE
Add patchedTimestamp to cluster status

### DIFF
--- a/azimuth_caas_operator/models/v1alpha1/cluster.py
+++ b/azimuth_caas_operator/models/v1alpha1/cluster.py
@@ -30,6 +30,9 @@ class ClusterStatus(schema.BaseModel):
     updatedTimestamp: schema.Optional[datetime.datetime] = pydantic.Field(
         None, description="The timestamp at which the resource was updated."
     )
+    patchedTimestamp: schema.Optional[datetime.datetime] = pydantic.Field(
+        None, description="The timestamp at which version was last changed."
+    )
     outputs: schema.Optional[schema.Dict[str, schema.Any]] = pydantic.Field(
         default_factory=dict
     )

--- a/azimuth_caas_operator/operator.py
+++ b/azimuth_caas_operator/operator.py
@@ -78,6 +78,11 @@ async def cluster_type_updated(body, name, namespace, labels, **kwargs):
         LOG.info("No update of uimeta needed.")
     else:
         LOG.info("Updating UI Meta.")
+        if cluster_type.status.phase != cluster_type_crd.ClusterTypePhase.PENDING:
+            # make cluster type unavailable while we update it
+            cluster_type.status.phase = cluster_type_crd.ClusterTypePhase.PENDING
+            await _update_cluster_type(K8S_CLIENT, name, namespace, cluster_type.status)
+
         ui_meta_obj = await _fetch_ui_meta_from_url(cluster_type.spec.uiMetaUrl)
         cluster_type.status = cluster_type_crd.ClusterTypeStatus(
             phase=cluster_type_crd.ClusterTypePhase.AVAILABLE,

--- a/azimuth_caas_operator/tests/base.py
+++ b/azimuth_caas_operator/tests/base.py
@@ -2,5 +2,4 @@ from oslotest import base
 
 
 class TestCase(base.BaseTestCase):
-
     """Test case base class for all unit tests."""

--- a/azimuth_caas_operator/tests/models/test_crds.py
+++ b/azimuth_caas_operator/tests/models/test_crds.py
@@ -334,6 +334,12 @@ class TestModels(base.TestCase):
                     "nullable": true,
                     "type": "string"
                   },
+                  "patchedTimestamp": {
+                    "description": "The timestamp at which version was last changed.",
+                    "format": "date-time",
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "outputs": {
                     "additionalProperties": {
                       "x-kubernetes-preserve-unknown-fields": true

--- a/azimuth_caas_operator/utils/cluster_type.py
+++ b/azimuth_caas_operator/utils/cluster_type.py
@@ -54,7 +54,9 @@ async def _cache_client_type(client, cluster, cluster_type_spec, cluster_version
     if cluster_version != cluster.spec.clusterTypeVersion:
         cluster_resource = await client.api(registry.API_VERSION).resource("clusters")
         await cluster_resource.patch(
-            cluster.metadata.name, dict(clusterTypeVersion=cluster_version)
+            cluster.metadata.name,
+            dict(clusterTypeVersion=cluster_version),
+            namespace=cluster.metadata.namespace,
         )
 
     cluster_status_resource = await client.api(registry.API_VERSION).resource(

--- a/azimuth_caas_operator/utils/cluster_type.py
+++ b/azimuth_caas_operator/utils/cluster_type.py
@@ -55,7 +55,7 @@ async def _cache_client_type(client, cluster, cluster_type_spec, cluster_version
         cluster_resource = await client.api(registry.API_VERSION).resource("clusters")
         await cluster_resource.patch(
             cluster.metadata.name,
-            dict(clusterTypeVersion=cluster_version),
+            dict(spec=dict(clusterTypeVersion=cluster_version)),
             namespace=cluster.metadata.namespace,
         )
 


### PR DESCRIPTION
Also stop erroring out when we spot that Azimuth has requested an different cluster version, just pick up the latest and log a warning in case something odd is happening.