### PR TITLE
Relax ARA allowed hosts

### DIFF
--- a/charts/ara/templates/deployment.yaml
+++ b/charts/ara/templates/deployment.yaml
@@ -27,13 +27,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: ARA_ALLOWED_HOSTS
-              value: >-
-                [
-                  "127.0.0.1",
-                  "localhost",
-                  "::1",
-                  "{{ include "ara.fullname" . }}.{{ .Release.Namespace }}"
-                ]
+              # Allow any hosts for ARA
+              # We rely on whatever is providing ingress to validate the host
+              value: '["*"]'
             - name: ARA_IGNORED_FACTS
               value: '["ansible_env_skip"]'
           ports:


### PR DESCRIPTION
Instead, rely on whatever is proxying access to validate the host