### PR TITLE
Sign the container images we build

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -7,6 +7,12 @@ jobs:
   build_push_operator_image:
     name: Build and push operator image
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token
+
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3
@@ -30,7 +36,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
-        uses: stackhpc/github-actions/docker-multiarch-build-push@master
+        uses: stackhpc/github-actions/docker-multiarch-build-push@better-signatures
         with:
           cache-key: azimuth-caas-operator
           context: .
@@ -38,6 +44,7 @@ jobs:
           push: true
           tags: ${{ steps.image-meta.outputs.tags }}
           labels: ${{ steps.image-meta.outputs.labels }}
+          sign_image: true
 
   build_push_ansible_runner_image:
     name: Build and push ansible runner image

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -7,7 +7,6 @@ jobs:
   build_push_operator_image:
     name: Build and push operator image
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       packages: write
@@ -36,7 +35,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
-        uses: stackhpc/github-actions/docker-multiarch-build-push@better-signatures
+        uses: stackhpc/github-actions/docker-multiarch-build-push@master
         with:
           cache-key: azimuth-caas-operator
           context: .
@@ -49,6 +48,10 @@ jobs:
   build_push_ansible_runner_image:
     name: Build and push ansible runner image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3
@@ -90,6 +93,7 @@ jobs:
           push: true
           tags: ${{ steps.image-meta.outputs.tags }}
           labels: ${{ steps.image-meta.outputs.labels }}
+          sign_image: true
 
   mirror_ara_image:
     name: Mirror and tag the latest ARA image

--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -23,6 +23,7 @@ options:
 additional_build_steps:
   prepend_base:
     # Give the user with UID 1000 a name
+    - RUN microdnf install shadow-utils -y
     - |
         RUN groupadd --gid 1000 runner && \
         useradd \

--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -5,7 +5,7 @@ version: 3
 
 images:
   base_image:
-    name: rockylinux:9-minimal
+    name: registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 dependencies:
   python_interpreter:

--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -11,9 +11,9 @@ dependencies:
   python_interpreter:
     package_system: python3
   ansible_core:
-    package_pip: ansible-core==2.15.1
+    package_pip: ansible-core==2.15.9
   ansible_runner:
-    package_pip: ansible-runner==2.3.3
+    package_pip: ansible-runner==2.3.4
   python: requirements.txt
   system: bindep.txt
 
@@ -39,3 +39,4 @@ additional_build_steps:
     # We don't want these in the final container - only the builder
     # It is required to build the wheel for netifaces
     - RUN microdnf install gcc python3-devel -y
+    - RUN microdnf upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 -y


### PR DESCRIPTION
Give the pipeline id-token permissions, so the
action can automatically sign the container images.

As an example, you can verify the signature like this:
```
cosign verify ghcr.io/stackhpc/azimuth-caas-operator:3ec0b58 \
  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
  --certificate-identity-regexp="https://github.com/stackhpc/azimuth-caas-operator/.github/.*"
```