### PR TITLE
Fix metrics

### DIFF
--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -63,8 +63,8 @@ metrics:
       - apiGroups:
           - caas.azimuth.stackhpc.com
         resources:
-          - cluster
-          - clustertype
+          - clusters
+          - clustertypes
         verbs:
           - list
           - watch


### PR DESCRIPTION
Tilt helm values are additive, so we missed the permissions
getting broken in the previous metrics fix.