### PR TITLE
Add ability to pause cluster reconciliation, including delete

### DIFF
--- a/azimuth_caas_operator/models/v1alpha1/cluster.py
+++ b/azimuth_caas_operator/models/v1alpha1/cluster.py
@@ -49,6 +49,7 @@ class ClusterSpec(schema.BaseModel):
     createdByUserId: schema.Optional[str] = None
     updatedByUsername: schema.Optional[str] = None
     updatedByUserId: schema.Optional[str] = None
+    paused: bool = False
 
 
 class Cluster(

--- a/azimuth_caas_operator/operator.py
+++ b/azimuth_caas_operator/operator.py
@@ -131,6 +131,11 @@ async def cluster_create(body, name, namespace, labels, **kwargs):
     # Before doing anything, ensure the clusterID is set
     await cluster_utils.ensure_cluster_id(K8S_CLIENT, cluster)
 
+    # If cluster reconciliation is paused, don't do anything else
+    if cluster.spec.paused:
+        LOG.info(f"Cluster {name} in {namespace} is paused - no action taken")
+        return
+
     # Check for an existing create job
     create_job = await ansible_runner.get_create_job_for_cluster(
         K8S_CLIENT, name, namespace
@@ -216,6 +221,11 @@ async def cluster_update(body, name, namespace, labels, **kwargs):
 
     # Before doing anything, ensure the clusterID is set
     await cluster_utils.ensure_cluster_id(K8S_CLIENT, cluster)
+
+    # If cluster reconciliation is paused, don't do anything else
+    if cluster.spec.paused:
+        LOG.info(f"Cluster {name} in {namespace} is paused - no action taken")
+        return
 
     # Fail if create is still in progress
     # Note that we don't care if create worked.
@@ -312,6 +322,11 @@ async def cluster_delete(body, name, namespace, labels, **kwargs):
 
     # Before doing anything, ensure the clusterID is set
     await cluster_utils.ensure_cluster_id(K8S_CLIENT, cluster)
+
+    # If cluster reconciliation is paused, don't do anything else
+    if cluster.spec.paused:
+        LOG.info(f"Cluster {name} in {namespace} is paused - no action taken")
+        return
 
     # Check for any pending jobs
     # and fail if we are still running a create job

--- a/azimuth_caas_operator/tests/models/test_crds.py
+++ b/azimuth_caas_operator/tests/models/test_crds.py
@@ -238,6 +238,9 @@ class TestModels(base.TestCase):
                   "updatedByUserId": {
                     "nullable": true,
                     "type": "string"
+                  },
+                  "paused": {
+                    "type": "boolean"
                   }
                 },
                 "required": [


### PR DESCRIPTION
Required for https://github.com/stackhpc/azimuth/pull/185, as it will allow tasks in azimuth-ops (WIP) to move existing clusters into the correct namespace (similar to `clusterctl move` for CAPI clusters) and add the ownership records to the corresponding identity platforms so that they are garbage collected correctly.