### PR TITLE
Enable FQCN debug output

### DIFF
--- a/azimuth_caas_operator/utils/ansible_runner.py
+++ b/azimuth_caas_operator/utils/ansible_runner.py
@@ -2,15 +2,15 @@ import base64
 import json
 import logging
 import os
-
 import yaml
-from cryptography.hazmat.primitives import serialization
+
 from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+
 from easykube import ApiError
 
 from azimuth_caas_operator.models.v1alpha1 import cluster as cluster_crd
-from azimuth_caas_operator.models.v1alpha1 import \
-    cluster_type as cluster_type_crd
+from azimuth_caas_operator.models.v1alpha1 import cluster_type as cluster_type_crd
 from azimuth_caas_operator.utils import cluster_type as cluster_type_utils
 from azimuth_caas_operator.utils import image as image_utils
 from azimuth_caas_operator.utils import k8s

--- a/azimuth_caas_operator/utils/ansible_runner.py
+++ b/azimuth_caas_operator/utils/ansible_runner.py
@@ -2,19 +2,18 @@ import base64
 import json
 import logging
 import os
+
 import yaml
-
-from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives import serialization
-
+from cryptography.hazmat.primitives.asymmetric import ed25519
 from easykube import ApiError
 
 from azimuth_caas_operator.models.v1alpha1 import cluster as cluster_crd
-from azimuth_caas_operator.models.v1alpha1 import cluster_type as cluster_type_crd
+from azimuth_caas_operator.models.v1alpha1 import \
+    cluster_type as cluster_type_crd
 from azimuth_caas_operator.utils import cluster_type as cluster_type_utils
 from azimuth_caas_operator.utils import image as image_utils
 from azimuth_caas_operator.utils import k8s
-
 
 LOG = logging.getLogger(__name__)
 
@@ -415,7 +414,7 @@ async def _get_job_outputs(client, job):
         if event_details["event"] == "runner_on_ok":
             event_data = event_details["event_data"]
             task_action = event_data["task_action"]
-            if task_action == "debug":
+            if task_action in {"debug", "ansible.builtin.debug"}:
                 debug_result = event_data.get("res", {})
                 outputs = debug_result.get("outputs", {})
                 if isinstance(outputs, dict):


### PR DESCRIPTION
When working on an Azimuth appliance, Ansible linting complains about:

1. Using the freeform version of debug for the outputs task
2. Not using the FQCN of the debug builtin

This PR addresses both issues, enabling output parsing when the appliance Ansible task looks like this:

```yaml
- ansible.builtin.debug: 
    var: outputs 
  vars: 
    outputs: 
      cluster_access_ip: "{{ cluster_floating_ip_address | default(None) }}" 
  delegate_to: localhost
```