### PR TITLE
Generate CRDs and package into chart

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -20,6 +20,26 @@ jobs:
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.9.0
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install Python packages
+      run: |
+        set -e
+        python -m pip install --upgrade pip
+        python -m pip install --no-deps -r ./requirements.txt
+        python -m pip install --no-deps -e .
+
+    - name: Generate CRDs
+      run: |
+        kcr_generate \
+          azimuth_caas_operator.models \
+          caas.azimuth.stackhpc.com \
+          ./charts/operator/files/crds \
+          --category azimuth
+
     - name: Run test
       timeout-minutes: 10
       run: tools/functional_test.sh

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -21,6 +21,26 @@ jobs:
           # when determining the number of commits since the last tag
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Python packages
+        run: |
+          set -e
+          python -m pip install --upgrade pip
+          python -m pip install --no-deps -r ./requirements.txt
+          python -m pip install --no-deps -e .
+
+      - name: Generate CRDs
+        run: |
+          kcr_generate \
+            azimuth_caas_operator.models \
+            caas.azimuth.stackhpc.com \
+            ./charts/operator/files/crds \
+            --category azimuth
+
       - name: Get SemVer version for current commit
         id: semver
         uses: stackhpc/github-actions/semver@master

--- a/azimuth_caas_operator/operator.py
+++ b/azimuth_caas_operator/operator.py
@@ -1,8 +1,6 @@
-import asyncio
 import datetime
 import logging
 import os
-import sys
 
 import aiohttp
 import kopf
@@ -24,32 +22,9 @@ K8S_CLIENT = None
 async def startup(settings, **kwargs):
     # Apply kopf setting to force watches to restart periodically
     settings.watching.client_timeout = int(os.environ.get("KOPF_WATCH_TIMEOUT", "600"))
+    # Initialise the Kubernetes client
     global K8S_CLIENT
     K8S_CLIENT = k8s.get_k8s_client()
-    # Create or update the CRDs
-    for crd in registry.get_crd_resources():
-        try:
-            await K8S_CLIENT.apply_object(crd, force=True)
-        except Exception:
-            LOG.exception("error applying CRD %s - exiting", crd["metadata"]["name"])
-            sys.exit(1)
-    LOG.info("All CRDs updated.")
-    # Give Kubernetes a chance to create the APIs for the CRDs
-    await asyncio.sleep(0.5)
-    # Check to see if the APIs for the CRDs are up
-    # If they are not, the kopf watches will not start properly
-    for crd in registry.get_crd_resources():
-        api_group = crd["spec"]["group"]
-        preferred_version = next(
-            v["name"] for v in crd["spec"]["versions"] if v["storage"]
-        )
-        api_version = f"{api_group}/{preferred_version}"
-        plural_name = crd["spec"]["names"]["plural"]
-        try:
-            _ = await K8S_CLIENT.get(f"/apis/{api_version}/{plural_name}")
-        except Exception:
-            LOG.exception("api for %s not available - exiting", crd["metadata"]["name"])
-            sys.exit(1)
 
 
 @kopf.on.cleanup()

--- a/azimuth_caas_operator/tests/test_operator.py
+++ b/azimuth_caas_operator/tests/test_operator.py
@@ -31,32 +31,6 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
             },
         }
 
-    @mock.patch("azimuth_caas_operator.models.registry.get_crd_resources")
-    @mock.patch("azimuth_caas_operator.utils.k8s.get_k8s_client")
-    async def test_startup_register_crds(self, mock_get, mock_crds):
-        fake_crd1 = self._generate_fake_crd("crd1.fake.io")
-        fake_crd2 = self._generate_fake_crd("crd2.fake.io")
-
-        mock_client = mock.AsyncMock()
-        mock_get.return_value = mock_client
-        mock_crds.return_value = [fake_crd1, fake_crd2]
-
-        mock_settings = mock.Mock()
-
-        await operator.startup(mock_settings)
-
-        # Test that the CRDs were applied
-        mock_client.apply_object.assert_has_awaits(
-            [mock.call(fake_crd1, force=True), mock.call(fake_crd2, force=True)]
-        )
-        # Test that the APIs were checked
-        mock_client.get.assert_has_awaits(
-            [
-                mock.call("/apis/fake.io/v1alpha1/crd1"),
-                mock.call("/apis/fake.io/v1alpha1/crd2"),
-            ]
-        )
-
     @mock.patch.object(operator, "K8S_CLIENT", new_callable=mock.AsyncMock)
     async def test_cleanup_calls_aclose(self, mock_client):
         await operator.cleanup()

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
     repository: file://../ara
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 5.15.3
+    version: 5.19.1
     alias: metrics
     condition: metrics.enabled

--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -51,3 +51,26 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 {{ include "azimuth-caas-operator.selectorLabels" . }}
 {{- end }}
+
+{{/*
+Produces the metadata for a CRD.
+*/}}
+{{- define "azimuth-caas-operator.crd.metadata" }}
+metadata:
+  labels: {{ include "azimuth-caas-operator.labels" . | nindent 4 }}
+  {{- if .Values.crds.keep }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+{{- end }}
+
+{{/*
+Loads a CRD from the specified file and merges in the metadata.
+*/}}
+{{- define "azimuth-caas-operator.crd" }}
+{{- $ctx := index . 0 }}
+{{- $path := index . 1 }}
+{{- $crd := $ctx.Files.Get $path | fromYaml }}
+{{- $metadata := include "azimuth-caas-operator.crd.metadata" $ctx | fromYaml }}
+{{- merge $crd $metadata | toYaml }}
+{{- end }}

--- a/charts/operator/templates/crds.yaml
+++ b/charts/operator/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.crds.enabled }}
+{{- range $path, $_ := .Files.Glob "files/crds/*.yaml" }}
+---
+{{ include "azimuth-caas-operator.crd" (list $ $path) }}
+{{- end }}
+{{- end }}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -84,6 +84,14 @@ metrics:
     create: true
     extraRules:
       - apiGroups:
+          - apiextensions.k8s.io
+        resources:
+          - customresourcedefinitions
+        verbs:
+          - list
+          - watch
+          - get
+      - apiGroups:
           - caas.azimuth.stackhpc.com
         resources:
           - clusters

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -84,14 +84,6 @@ metrics:
     create: true
     extraRules:
       - apiGroups:
-          - apiextensions.k8s.io
-        resources:
-          - customresourcedefinitions
-        verbs:
-          - list
-          - watch
-          - get
-      - apiGroups:
           - caas.azimuth.stackhpc.com
         resources:
           - clusters

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -84,6 +84,14 @@ metrics:
     create: true
     extraRules:
       - apiGroups:
+          - apiextensions.k8s.io
+        resources:
+          - customresourcedefinitions
+        verbs:
+          - list
+          - watch
+          - get
+      - apiGroups:
           - caas.azimuth.stackhpc.com
         resources:
           - clusters
@@ -95,45 +103,44 @@ metrics:
   # Configure kube-state-metrics to report only on our custom resources
   extraArgs:
     - --custom-resource-state-only=true
-  customResourceState:
-    enabled: true
-    config:
-      kind: CustomResourceStateMetrics
-      spec:
-        resources:
-          - groupVersionKind:
-              group: caas.azimuth.stackhpc.com
-              version: v1alpha1
-              kind: Cluster
-            metricNamePrefix: azimuth_caas_clusters
-            labelsFromPath:
-              cluster_namespace: [metadata, namespace]
-              cluster_name: [metadata, name]
-              cluster_type_name: [spec, clusterTypeName]
-              cluster_type_version: [spec, clusterTypeVersion]
-            metrics:
-              - name: phase
-                help: "Cluster phase"
-                each:
-                  type: Info
-                  info:
-                    labelsFromPath:
-                      phase: [status, phase]
+    - --custom-resource-state-config
+    - |
+        kind: CustomResourceStateMetrics
+        spec:
+          resources:
+            - groupVersionKind:
+                group: caas.azimuth.stackhpc.com
+                version: v1alpha1
+                kind: Cluster
+              metricNamePrefix: azimuth_caas_clusters
+              labelsFromPath:
+                cluster_namespace: [metadata, namespace]
+                cluster_name: [metadata, name]
+                cluster_type_name: [spec, clusterTypeName]
+                cluster_type_version: [spec, clusterTypeVersion]
+              metrics:
+                - name: phase
+                  help: "Cluster phase"
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        phase: [status, phase]
 
-          - groupVersionKind:
-              group: caas.azimuth.stackhpc.com
-              version: v1alpha1
-              kind: ClusterType
-            metricNamePrefix: azimuth_caas_clustertypes
-            labelsFromPath:
-              cluster_type_namespace: [metadata, namespace]
-              cluster_type_name: [metadata, name]
-              cluster_type_version: [metadata, resourceVersion]
-            metrics:
-              - name: phase
-                help: "Cluster type phase"
-                each:
-                  type: Info
-                  info:
-                    labelsFromPath:
-                      phase: [status, phase]
+            - groupVersionKind:
+                group: caas.azimuth.stackhpc.com
+                version: v1alpha1
+                kind: ClusterType
+              metricNamePrefix: azimuth_caas_clustertypes
+              labelsFromPath:
+                cluster_type_namespace: [metadata, namespace]
+                cluster_type_name: [metadata, name]
+                cluster_type_version: [metadata, resourceVersion]
+              metrics:
+                - name: phase
+                  help: "Cluster type phase"
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        phase: [status, phase]

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -1,3 +1,10 @@
+# Configuration for the CRDs
+crds:
+  # Indicates whether CRDs should be managed by the release
+  enabled: true
+  # Indicates whether CRDs should be kept when the release is removed
+  keep: true
+
 # Config for the operator
 config:
   # The URL for Consul

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ httpx==0.27.0
 idna==3.4
 iso8601==2.1.0
 kopf==1.36.2
-kube-custom-resource==0.2.0
+kube-custom-resource==0.4.0
 multidict==6.0.5
 pbr==6.0.0
 pycparser==2.21


### PR DESCRIPTION
This fixes an issue with KSM behaving erratically when it starts before the CRDs it watches are available, resulting in duplicate metrics.